### PR TITLE
Add workaround for poisoned connection pool

### DIFF
--- a/src/helpers/error_handlers.py
+++ b/src/helpers/error_handlers.py
@@ -53,6 +53,11 @@ async def request_timeout(request, exception):
 
 
 async def pool_timeout_error(request, exception):
+    if request.endpoint.startswith("Priviblur.TumblrMedia"):
+        request.app.ctx.PoolTimeoutTracker.increment_total(request.endpoint)
+    else:
+        request.app.ctx.PoolTimeoutTracker.increment_total("main")
+
     return await sanic_ext.render(
         "misc/generic_error.jinja",
         context={

--- a/src/helpers/pool_timeout_tracker.py
+++ b/src/helpers/pool_timeout_tracker.py
@@ -1,0 +1,36 @@
+"""A simple counter to track how many requests experienced a PoolTimeout
+
+Due to an upstream problem with httpx, the connection pool can become poisoned
+with broken connections that'd always raise a PoolTimeout. Once the entire pool
+becomes poisoned, all requests will fail.
+
+By tracking the amount of PoolTimeouts (with frequent resets), we can detect
+when a pool becomes poisoned and to create a new pool to replace it
+
+For more information see https://github.com/syeopite/priviblur/issues/4
+"""
+
+class PoolTimeoutTracker:
+    """Wraps a dictionary counting amount and origin of PoolTimeouts
+
+    tracker = PoolTimeoutTracker()
+    tracker.increment("someorigin")        # Increments both total and successful request count
+    tracker.increment_total("someorigin")  # Increments only the total request count (failure)
+    """
+    def __init__(self):
+        self.counter = {}
+
+    def increment_total(self, origin):
+        """Increments the total amount of requests in the pool"""
+        if self.counter.get(origin):
+            self.counter[origin]["total"] += 1
+        else:
+            self.counter[origin] = {"total": 1, "success": 0,}
+
+    def increment(self, origin):
+        """Increments the total and successful request count in the pool"""
+        if self.counter.get(origin):
+            self.counter[origin]["total"] += 1
+            self.counter[origin]["success"] += 1
+        else:
+            self.counter[origin] = {"total": 1, "success": 1}

--- a/src/jobs/refresh_pool.py
+++ b/src/jobs/refresh_pool.py
@@ -1,0 +1,47 @@
+import asyncio
+import functools
+
+import orjson
+
+from .. import priviblur_extractor
+
+async def refresh_pool(app, origin, create_image_client):
+    """Refreshes the connection pool identified by `origin`"""
+    match origin:
+        case "Priviblur.TumblrMedia._64_media":
+            app.ctx.Media64Client = create_image_client("https://64.media.tumblr.com")
+        case "Priviblur.TumblrMedia._49_media":
+            app.ctx.Media49Client = create_image_client("https://49.media.tumblr.com")
+        case "Priviblur.TumblrMedia._44_media":
+            app.ctx.Media44Client = create_image_client("https://44.media.tumblr.com")
+        case "Priviblur.TumblrMedia._tb_assets":
+            app.ctx.TumblrAssetClient = create_image_client("https://assets.tumblr.com")
+        case "Priviblur.TumblrMedia._tb_static":
+            app.ctx.TumblrStaticClient = create_image_client("https://static.tumblr.com")
+        case _:
+            app.ctx.TumblrAPI = await priviblur_extractor.TumblrAPI.create(
+                app.ctx.PRIVIBLUR_CONFIG.backend.main_request_timeout,
+                json_loads=orjson.loads,
+                post_success_function=functools.partial(app.ctx.PoolTimeoutTracker.increment, "main")
+            )
+
+async def refresh_pool_task(app, create_image_client):
+    """Detects and refreshes poisoned connection pool"""
+    amount_of_pools_refreshed = 0
+
+    try:
+        while True:
+            for origin, count in app.ctx.PoolTimeoutTracker.counter.items():
+                # If a pool only has a 70% success rate then we'll refresh the pool
+                if round(count["success"]/count["total"], 2) < 0.70:
+                    app.ctx.LOGGER.info("Refreshing connection pool for \"{origin}\"")
+                    await refresh_pool(app, origin, create_image_client)
+                    amount_of_pools_refreshed += 1
+
+            app.ctx.LOGGER.info(f"Finished pool refresh task. Refreshed {amount_of_pools_refreshed} pools")
+            # The counter is reset here as to ensure we don't get a success rate so high that failures won't
+            # be able to budge the success rate
+            app.ctx.PoolTimeoutTracker.counter = {}
+            await asyncio.sleep(900)
+    except asyncio.exceptions.CancelledError:
+        pass

--- a/src/priviblur_extractor/api/api.py
+++ b/src/priviblur_extractor/api/api.py
@@ -30,7 +30,7 @@ class TumblrAPI:
     }
 
     @classmethod
-    async def create(cls, client=None, main_request_timeout=10, json_loads=json.loads):
+    async def create(cls, client=None, main_request_timeout=10, json_loads=json.loads,  post_success_function = lambda: True):
         """Creates a Tumblr API instance with the given client. Automatically creates a client obj if not given."""
         if not client:
             client = httpx.AsyncClient(
@@ -40,12 +40,13 @@ class TumblrAPI:
                 timeout=main_request_timeout  # TODO allow fine-tuning the different types of timeouts
             )
 
-        return cls(client, json_loads)
+        return cls(client, json_loads, post_success_function)
 
-    def __init__(self, client: httpx.AsyncClient, json_loads=json.loads):
+    def __init__(self, client: httpx.AsyncClient, json_loads=json.loads, post_success_function = lambda: True):
         """Initializes a TumblrAPI instance with the given client"""
         self.client = client
         self.json_loader = json_loads
+        self.post_success_function = post_success_function
 
     async def _get_json(self, endpoint, url_params=""):
         """Internal method that does the actual request to Tumblr"""
@@ -108,6 +109,8 @@ class TumblrAPI:
 
             raise exceptions.TumblrErrorResponse(message, code, details, internal_code)
 
+        self.post_success_function()
+
         return result
 
     async def explore(self):
@@ -152,7 +155,6 @@ class TumblrAPI:
         url_parameters["fields[blogs]"] = fields
 
         return await self._get_json("explore/trending", url_parameters)
-
     
     async def explore_today(self, *, continuation: Optional[str] = None, fields: str = rconf.EXPLORE_BLOG_INFO_FIELDS):
         """Requests the /explore/home/today endpoint
@@ -171,8 +173,7 @@ class TumblrAPI:
             url_parameters["cursor"] = continuation
 
         return await self._get_json("explore/home/today", url_parameters)
-    
-    
+
     async def explore_post(self, post_type: rconf.ExplorePostTypeFilters, *, continuation: Optional[str] = None,
                            reblog_info: bool = True,
                            fields: str = rconf.EXPLORE_BLOG_INFO_FIELDS,):

--- a/src/routes/media.py
+++ b/src/routes/media.py
@@ -55,3 +55,9 @@ async def _tb_assets(request: sanic.Request, path: str):
 async def _tb_static(request: sanic.Request, path: str):
     """Proxies the requested media from static.tumblr.com"""
     return await get_media(request, request.app.ctx.TumblrStaticClient, path)
+
+
+@media.on_response
+async def post_response(request, response):
+    if response.status == 200:
+        request.app.ctx.PoolTimeoutTracker.increment(request.endpoint)

--- a/src/server.py
+++ b/src/server.py
@@ -18,8 +18,9 @@ from npf_renderer import VERSION as NPF_RENDERER_VERSION, format_npf
 from . import routes, priviblur_extractor
 from . import priviblur_extractor
 from .config import load_config
-from .helpers import setup_logging, helpers, error_handlers
+from .helpers import setup_logging, helpers, error_handlers, pool_timeout_tracker
 from .version import VERSION, CURRENT_COMMIT
+from .jobs import refresh_pool
 
 
 # Load configuration file 
@@ -57,12 +58,19 @@ app.ctx.BLACKLIST_RESPONSE_HEADERS = ("access-control-allow-origin", "alt-svc", 
 app.ctx.PRIVIBLUR_CONFIG = config
 app.ctx.translate = helpers.translate
 
+app.ctx.PoolTimeoutTracker = pool_timeout_tracker.PoolTimeoutTracker()
+
+tasks = []
+
 @app.listener("before_server_start")
 async def initialize(app):
+
     priviblur_backend = app.ctx.PRIVIBLUR_CONFIG.backend
 
     app.ctx.TumblrAPI = await priviblur_extractor.TumblrAPI.create(
-        main_request_timeout=priviblur_backend.main_response_timeout, json_loads=orjson.loads
+        main_request_timeout=priviblur_backend.main_response_timeout,
+        json_loads=orjson.loads,
+        post_success_function=functools.partial(app.ctx.PoolTimeoutTracker.increment, "main")
     )
 
     media_request_headers = {
@@ -76,33 +84,23 @@ async def initialize(app):
 
     # TODO set pool size for image requests
 
-    def create_image_client(url, timeout):
-        media_headers = copy.copy(media_request_headers)
-        media_headers["host"] = url
-        return httpx.AsyncClient(base_url=url, headers=media_request_headers, http2=True, timeout=timeout)
+    def create_image_client(url):
+        return httpx.AsyncClient(
+            base_url=url,
+            headers=media_request_headers,
+            http2=True,
+            timeout=priviblur_backend.image_response_timeout
+        )
 
-    app.ctx.Media64Client = create_image_client(
-        "https://64.media.tumblr.com", priviblur_backend.image_response_timeout
-    )
+    app.ctx.Media64Client = create_image_client("https://64.media.tumblr.com")
+    app.ctx.Media49Client = create_image_client("https://49.media.tumblr.com")
+    app.ctx.Media44Client = create_image_client("https://44.media.tumblr.com")
+    app.ctx.TumblrAssetClient = create_image_client("https://assets.tumblr.com")
+    app.ctx.TumblrStaticClient = create_image_client("https://static.tumblr.com")
 
-    app.ctx.Media49Client = create_image_client(
-        "https://49.media.tumblr.com", priviblur_backend.image_response_timeout
-    )
-
-    app.ctx.Media44Client = create_image_client(
-        "https://44.media.tumblr.com", priviblur_backend.image_response_timeout
-    )
-
-    app.ctx.TumblrAssetClient = create_image_client(
-        "https://assets.tumblr.com", priviblur_backend.image_response_timeout
-    )
-
-    app.ctx.TumblrStaticClient = create_image_client(
-        "https://static.tumblr.com", priviblur_backend.image_response_timeout
-    )
+    tasks.append(app.add_task(refresh_pool.refresh_pool_task(app, create_image_client)))
 
     # Add additional jinja filters and functions
-
 
     app.ext.environment.filters["encodepathsegment"] = functools.partial(urllib.parse.quote, safe="")
 
@@ -159,6 +157,17 @@ async def before_all_routes(request, response):
         ]
     )
 
+
+@app.listener("after_server_stop")
+async def shutdown(app):
+    # Stop all background tasks
+    for task in tasks:
+        task.cancel()
+        await task
+
+@app.listener("reload_process_stop")
+async def reload_shutdown(app):
+    return await shutdown(app)
 
 # TODO Extract
 


### PR DESCRIPTION
https://github.com/syeopite/priviblur/issues/4 appears to be caused by faulty connections that aren't properly released which will result in a PoolTimeout exception when attempting to fetch one.

When enough of a pool gets poisoned, all requests will fail due to the PoolTimeout exceptions.

This commit implements a workaround by detecting and then reinitializing poisoned connection pools which would clear all of the faulty connections.

Closes #4