### PR TITLE
Fix fetch_polls=1 for slugless URLs

### DIFF
--- a/src/routes/blogs.py
+++ b/src/routes/blogs.py
@@ -78,7 +78,7 @@ async def _blog_post_no_slug(request: sanic.Request, blog: str, post_id: str):
         # Fetch blog info and some posts from before this post
         blog_info = await get_blog_posts(request.app.ctx, blog, before_id=post.id)
 
-        if request.args.get("fetch_polls") in {1, "true"}:
+        if request.args.get("fetch_polls") in {"1", "true"}:
             fetch_poll_results = True
         else:
             fetch_poll_results = False


### PR DESCRIPTION
This is a bit of a nitpick I found while reading code, but https://priviblur.zangetsu.kaizoku.cyou/owlmond/742708107816370176?fetch_polls=1 doesn't work while https://priviblur.zangetsu.kaizoku.cyou/kaylasartwork/742675030696198144/alert-alert-we-have-an-eris-face-reveal?fetch_polls=1 does