### PR TITLE
Reduce build dependencies in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,11 +7,13 @@ COPY ./src/ ./src/
 COPY ./assets/ ./assets/
 COPY ./locales/ ./locales/
 
-# Rust is needed for orjson
-RUN apk add --no-cache git python3 py3-pip rust cargo tini && \
+RUN apk add --no-cache git python3 py3-setuptools tini && \
     addgroup -g 1000 -S priviblur && \
     adduser -u 1000 -S priviblur -G priviblur && \
-    pip3 install --break-system-packages -r requirements.txt && \
+    apk add --no-cache py3-pip && \
+    pip3 install --no-cache-dir --break-system-packages -r requirements.txt && \
+    pip3 cache purge && \
+    apk del py3-pip && \
     pybabel compile -d locales -D priviblur && \
     # chown is needed otherwise git will error out with "fatal: detected dubious ownership in repository at '/priviblur'"
     chown -R priviblur:priviblur /priviblur && \ 


### PR DESCRIPTION
`orjson` is already installed as a musl binary (on amd64 and arm64).

`site-packages` uses the most storage, so a multi-stage build (like copying a venv) doesn't help reduce it further. (Although it would help if you do want to build from source packages)

Fixes #58 