### PR TITLE
remove trailing slash from instances.md

### DIFF
--- a/instances.md
+++ b/instances.md
@@ -5,14 +5,14 @@
 |[pb.bloat.cat](https://pb.bloat.cat)|Romania|No|No|
 |[tb.opnxng.com](https://tb.opnxng.com)|Singapore|No|No|
 |[priviblur.pussthecat.org](https://priviblur.pussthecat.org)|Germany|No|No|
-|[priviblur.thebunny.zone](https://priviblur.thebunny.zone/)|Croatia|No|No|
+|[priviblur.thebunny.zone](https://priviblur.thebunny.zone)|Croatia|No|No|
 
 
 ### Tor Onion Services
 
 |URL|Location|Modified|
 |-|-|-|
-|[priviblur.bunny5exbgbp4sqe2h2rfq2brgrx3dhohdweonepzwfgumfyygb35wyd.onion](http://priviblur.bunny5exbgbp4sqe2h2rfq2brgrx3dhohdweonepzwfgumfyygb35wyd.onion/)|Croatia|No|
+|[priviblur.bunny5exbgbp4sqe2h2rfq2brgrx3dhohdweonepzwfgumfyygb35wyd.onion](http://priviblur.bunny5exbgbp4sqe2h2rfq2brgrx3dhohdweonepzwfgumfyygb35wyd.onion)|Croatia|No|
 
 ### Rules
   - Your instance must not be more than a month out of date compared with either the latest commit or latest release. 


### PR DESCRIPTION
removes the trailing slash from the 'priviblur.thebunny.zone' instance as the [regex filter LibRedirect uses](https://github.com/libredirect/instances/blob/a64c19a6b1fa9a0a0d6cca6746bb364435cd7cf9/services/other.py#L213) was detecting it and excluding the instance