### PR TITLE
Use middleware to validate post slugs

### DIFF
--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -5,7 +5,7 @@ BLUEPRINTS = (
     media.media,
     search.search,
     tagged.tagged,
-    blogs.blogs,
+    blogs.blogs_group,
     assets.assets,
     priviblur.priviblur,
     miscellaneous.miscellaneous,

--- a/src/routes/blogs/__init__.py
+++ b/src/routes/blogs/__init__.py
@@ -1,0 +1,8 @@
+from sanic import Blueprint
+
+from . import blogs, post
+
+blogs_group = Blueprint.group(
+    blogs.blogs, post.blog_post_bp,
+    url_prefix="/<blog:([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})>"
+)

--- a/src/routes/blogs/blogs.py
+++ b/src/routes/blogs/blogs.py
@@ -1,33 +1,12 @@
-import html
 import urllib.parse
 
 import sanic
 import sanic_ext
 
-from .. import priviblur_extractor
-from ..cache import get_blog_posts, get_blog_post, get_blog_search_results
+from ... import priviblur_extractor
+from ...cache import get_blog_posts, get_blog_search_results
 
-blogs = sanic.Blueprint("blogs", url_prefix="/<blog:([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})>")
-
-
-async def render_blog_post(request, blog, post):
-    """Handles the logic for rendering viewing a single blog post"""
-    blog_info = priviblur_extractor.models.timelines.BlogTimeline(post.blog, (), None, None)
-
-    if request.args.get("fetch_polls") in ("1", "true"):
-        fetch_poll_results = True
-    else:
-        fetch_poll_results = False
-
-    return await sanic_ext.render(
-        "blog/blog_post.jinja",
-        context={
-            "app": request.app,
-            "blog": blog_info,
-            "element": post,
-            "request_poll_data" : fetch_poll_results,
-        }
-    )
+blogs = sanic.Blueprint("blogs", url_prefix="/")
 
 
 @blogs.get("/")
@@ -116,44 +95,13 @@ async def query_param_redirect(request: sanic.Request, blog: str):
         return sanic.redirect(request.app.url_for("blogs._blog_posts", blog=blog))
 
 
-# Single post
-
-@blogs.get("/<post_id:int>")
-async def _blog_post_no_slug(request: sanic.Request, blog: str, post_id: str):
-    blog = urllib.parse.unquote(blog)
-    post = (await get_blog_post(request.app.ctx, blog, post_id)).elements[0]
-
-    if post.slug:
-        return sanic.redirect(request.app.url_for("blogs._blog_post", blog=blog, post_id=post_id, slug=post.slug, **request.args))
-    else:
-        return await render_blog_post(request, blog, post)
-
-
-@blogs.get("/<post_id:int>/<slug:str>")
-async def _blog_post(request: sanic.Request, blog: str, post_id: str, slug: str):
-    blog = urllib.parse.unquote(blog)
-    slug = urllib.parse.unquote(slug)
-
-    post = (await get_blog_post(request.app.ctx, blog, post_id)).elements[0]
-
-    # Redirect to the correct slug when the given slug does not match the one of the post
-    if post.slug != slug:
-        # Unless of course the slug is empty. In that case we'll remove the slug. 
-        if post.slug:
-            return sanic.redirect(request.app.url_for("blogs._blog_post", blog=blog, post_id=post_id, slug=post.slug, **request.args))
-        else:
-            return sanic.redirect(request.app.url_for("blogs._blog_post_no_slug", blog=blog, post_id=post_id, **request.args))
-    else:
-        return await render_blog_post(request, blog, post)
-
-
 # Redirects for /post/...
 
 @blogs.get("/post/<post_id:int>")
 async def redirect_slash_post_no_slug(request: sanic.Request, blog: str, post_id: str):
-    return sanic.redirect(request.app.url_for("blogs._blog_post_no_slug", blog=blog, post_id=post_id))
+    return sanic.redirect(request.app.url_for("blog_post._blog_post_no_slug", blog=blog, post_id=post_id))
 
 
 @blogs.get("/post/<post_id:int>/<slug:str>")
 async def redirect_slash_post(request: sanic.Request, blog: str, post_id: str, slug: str):
-    return sanic.redirect(request.app.url_for("blogs._blog_post", blog=blog, post_id=post_id, slug=slug))
+    return sanic.redirect(request.app.url_for("blog_post._blog_post", blog=blog, post_id=post_id, slug=slug))

--- a/src/routes/blogs/post.py
+++ b/src/routes/blogs/post.py
@@ -8,9 +8,55 @@ from ... import cache, priviblur_extractor
 blog_post_bp = sanic.Blueprint("blog_post", url_prefix="/<post_id:int>")
 
 
-async def render_blog_post(request, blog, post):
-    """Handles the logic for rendering viewing a single blog post"""
-    blog_info = priviblur_extractor.models.timelines.BlogTimeline(post.blog, (), None, None)
+def get_blog_post_path(request):
+    """Returns the path to the user requested blog post endpoint"""
+    return f"/{'/'.join(str(path_component) for path_component in request.match_info.values())}"
+
+
+@blog_post_bp.on_request
+async def before_blog_post_request(request):
+    """Validates that the user requested endpoint contains a valid slug
+
+    Redirects to a valid URL if otherwise
+    """
+    # Ensure that the slug is correct when present
+    blog = urllib.parse.unquote(request.match_info["blog"])
+    post_id = request.match_info["post_id"]
+
+    post = (await cache.get_blog_post(request.app.ctx, blog, post_id)).elements[0]
+
+    # Check if slug is passed
+    if slug := request.match_info.get("slug"):
+        # Redirect to the correct slug if the given slug does not match the post's slug
+        if slug != post.slug:
+            # Unless of course the post doesn't have a slug in the first place in which
+            # we'll redirect to the path without a slug
+            if not post.slug:
+                del request.match_info["slug"]
+                return sanic.redirect(get_blog_post_path(request))
+            else:
+                # Correct post slug and redirect
+                request.match_info["slug"] = post.slug
+                return sanic.redirect(get_blog_post_path(request))
+    elif post.slug:
+        # If the post has a slug but a slug is not given then we'll need to redirect
+        # the user to a path with the slug due to how Tumblr works.
+
+        current_path = [str(path_component) for path_component in request.match_info.values()]
+
+        # Current path is `/<blog>/<post_id>/*`
+        # as such the slug needs to be inserted at position 2
+        current_path.insert(2, post.slug)
+
+        return sanic.redirect(f"/{'/'.join(current_path)}")
+
+    request.ctx.parsed_post = post
+
+
+@blog_post_bp.get("/")
+@blog_post_bp.get("/<slug:str>", name="_blog_post_with_slug")
+async def _blog_post(request: sanic.Request, **kwargs):
+    blog_info = priviblur_extractor.models.timelines.BlogTimeline(request.ctx.parsed_post.blog, (), None, None)
 
     if request.args.get("fetch_polls") in ("1", "true"):
         fetch_poll_results = True
@@ -22,37 +68,7 @@ async def render_blog_post(request, blog, post):
         context={
             "app": request.app,
             "blog": blog_info,
-            "element": post,
+            "element": request.ctx.parsed_post,
             "request_poll_data" : fetch_poll_results,
         }
     )
-
-# Single post
-
-@blog_post_bp.get("/")
-async def _blog_post_no_slug(request: sanic.Request, blog: str, post_id: str):
-    blog = urllib.parse.unquote(blog)
-    post = (await cache.get_blog_post(request.app.ctx, blog, post_id)).elements[0]
-
-    if post.slug:
-        return sanic.redirect(request.app.url_for("blogs._blog_post", blog=blog, post_id=post_id, slug=post.slug, **request.args))
-    else:
-        return await render_blog_post(request, blog, post)
-
-
-@blog_post_bp.get("/<slug:str>")
-async def _blog_post(request: sanic.Request, blog: str, post_id: str, slug: str):
-    blog = urllib.parse.unquote(blog)
-    slug = urllib.parse.unquote(slug)
-
-    post = (await cache.get_blog_post(request.app.ctx, blog, post_id)).elements[0]
-
-    # Redirect to the correct slug when the given slug does not match the one of the post
-    if post.slug != slug:
-        # Unless of course the slug is empty. In that case we'll remove the slug. 
-        if post.slug:
-            return sanic.redirect(request.app.url_for("blogs._blog_post", blog=blog, post_id=post_id, slug=post.slug, **request.args))
-        else:
-            return sanic.redirect(request.app.url_for("blogs._blog_post_no_slug", blog=blog, post_id=post_id, **request.args))
-    else:
-        return await render_blog_post(request, blog, post)

--- a/src/routes/blogs/post.py
+++ b/src/routes/blogs/post.py
@@ -1,0 +1,58 @@
+import urllib.parse
+
+import sanic
+import sanic_ext
+
+from ... import cache, priviblur_extractor
+
+blog_post_bp = sanic.Blueprint("blog_post", url_prefix="/<post_id:int>")
+
+
+async def render_blog_post(request, blog, post):
+    """Handles the logic for rendering viewing a single blog post"""
+    blog_info = priviblur_extractor.models.timelines.BlogTimeline(post.blog, (), None, None)
+
+    if request.args.get("fetch_polls") in ("1", "true"):
+        fetch_poll_results = True
+    else:
+        fetch_poll_results = False
+
+    return await sanic_ext.render(
+        "blog/blog_post.jinja",
+        context={
+            "app": request.app,
+            "blog": blog_info,
+            "element": post,
+            "request_poll_data" : fetch_poll_results,
+        }
+    )
+
+# Single post
+
+@blog_post_bp.get("/")
+async def _blog_post_no_slug(request: sanic.Request, blog: str, post_id: str):
+    blog = urllib.parse.unquote(blog)
+    post = (await cache.get_blog_post(request.app.ctx, blog, post_id)).elements[0]
+
+    if post.slug:
+        return sanic.redirect(request.app.url_for("blogs._blog_post", blog=blog, post_id=post_id, slug=post.slug, **request.args))
+    else:
+        return await render_blog_post(request, blog, post)
+
+
+@blog_post_bp.get("/<slug:str>")
+async def _blog_post(request: sanic.Request, blog: str, post_id: str, slug: str):
+    blog = urllib.parse.unquote(blog)
+    slug = urllib.parse.unquote(slug)
+
+    post = (await cache.get_blog_post(request.app.ctx, blog, post_id)).elements[0]
+
+    # Redirect to the correct slug when the given slug does not match the one of the post
+    if post.slug != slug:
+        # Unless of course the slug is empty. In that case we'll remove the slug. 
+        if post.slug:
+            return sanic.redirect(request.app.url_for("blogs._blog_post", blog=blog, post_id=post_id, slug=post.slug, **request.args))
+        else:
+            return sanic.redirect(request.app.url_for("blogs._blog_post_no_slug", blog=blog, post_id=post_id, **request.args))
+    else:
+        return await render_blog_post(request, blog, post)

--- a/src/server.py
+++ b/src/server.py
@@ -179,7 +179,7 @@ async def robotstxt_route(request):
     return await sanic.file("./assets/robots.txt")
 
 
-@app.middleware("request")
+@app.middleware("request", priority=1)
 async def before_all_routes(request):
     request.ctx.preferences = preferences.UserPreferences(
             **config.default_user_preferences._asdict()


### PR DESCRIPTION
This PR removes the slug check logic from the former route handlers
`_blog_post` and `_blog_post_no_slug`. Replacing this, is a middleware
that handles the slug check logic instead.

By using a middleware, we can apply this logic uniformly to all
additional blog post routes. For example for a post note viewer
ensuring that the endpoints to view post notes always has the correct
slug if applicable, and to remove the given slug if unnecessary.

As the logic that separated the slug and slugless post routes have
been transformed to a single middleware, these two routes have been
merged to use the same handler.