### PR TITLE
Add https config option to enable secure cookies

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -7,6 +7,10 @@
     # # This is primary used to generate links to the instance
     # domain =
 
+    # Enables secure cookies and forces all links
+    # to priviblur to use the `https://` scheme
+    https = false
+
     # # Amount of worker Priviblur instances to spawn. Increases speed significantly.
     # workers = 1
 

--- a/src/config/deployment.py
+++ b/src/config/deployment.py
@@ -8,6 +8,8 @@ class DeploymentConfig(NamedTuple):
         port: Port to listen for connections.
         domain: Domain name under which this instance is hosted.
 
+        https: Enables secure cookies and forces all links to priviblur to use the `https://` scheme
+
         workers: Amount of worker Priviblur instances to spawn.
             Increases speed significantly
 
@@ -23,6 +25,8 @@ class DeploymentConfig(NamedTuple):
     host: str = "127.0.0.1"
     port: int = 8080
     domain: Optional[str] = None
+
+    https: bool = False
 
     workers: int = 1
 

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -63,10 +63,10 @@ class UserPreferences:
 
     def construct_cookie(self, request):
         """Serializes user preferences into a cookie"""
-        if request.scheme == "http":
-            secure = False
-        else:
+        if request.app.ctx.PRIVIBLUR_CONFIG.deployment.https is True:
             secure = True
+        else:
+            secure = False
 
         cookie = {
             "key": "settings",


### PR DESCRIPTION
`request.scheme` doesn't work when Priviblur is under a reverse proxy