### PR TITLE
Example config: improve doc for language config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -52,7 +52,7 @@
 #     theme = "auto"
 #
 #     # User interface language
-#     # For available options see locales dir
+#     # For available options see SUPPORTED_LANGUAGES constant in src/helpers/i18n.py
 #     language = "en_US"
 
 


### PR DESCRIPTION
It is incorrect to say to check the locales dir for supported languages as languages have to be explicitly enabled in the `SUPPORTED_LANGUAGES` constant for Priviblur to use it.