### PR TITLE
Ensure 404 error when accessing /access/ dir

### DIFF
--- a/src/exceptions/error_handlers/miscellaneous_errors.py
+++ b/src/exceptions/error_handlers/miscellaneous_errors.py
@@ -24,7 +24,7 @@ async def request_timeout(request, exception):
     )
 
 
-@miscellaneous_errors.register(sanic.exceptions.NotFound)
+@miscellaneous_errors.register(sanic.exceptions.NotFound, IsADirectoryError)
 async def error_404(request, exception):
     return await sanic_ext.render(
         "misc/msg_error.jinja",

--- a/src/routes/assets.py
+++ b/src/routes/assets.py
@@ -1,5 +1,4 @@
 import sanic
-import sanic_ext
 
 from npf_renderer.utils import BASIC_LAYOUT_CSS
 
@@ -7,6 +6,7 @@ assets = sanic.Blueprint("assets", url_prefix="/assets")
 
 # Static assets
 assets.static("/", "assets")
+
 
 @assets.get("/css/base-post-layout.css")
 async def base_post_layout(request):


### PR DESCRIPTION
Usually Priviblur raises a `IsADirectoryError` when one attempts to access `/assets/`

This commit changes that error to show a generic 404 screen.