### PR TITLE
Fix blog search pagination

### DIFF
--- a/src/priviblur_extractor/__init__.py
+++ b/src/priviblur_extractor/__init__.py
@@ -1,4 +1,4 @@
 from .api import TumblrAPI
-from .parse import parse_timeline, parse_blog_timeline, parse_post_list
+from .parse import parse_timeline, parse_blog_timeline
 from .helpers import exceptions as priviblur_exceptions
 from . import models

--- a/src/priviblur_extractor/models/base.py
+++ b/src/priviblur_extractor/models/base.py
@@ -3,7 +3,7 @@ from typing import Optional, NamedTuple, Tuple
 # Used for cache busting
 # Applied when .to_json_serialisable() is called
 # Removed from serialized back with from_json()
-VERSION = 2
+VERSION = 3
 
 class Cursor(NamedTuple):
     """ Object representing Tumblr's API's "Next" object.

--- a/src/priviblur_extractor/parse/__init__.py
+++ b/src/priviblur_extractor/parse/__init__.py
@@ -1,1 +1,1 @@
-from .base import parse_timeline, parse_blog_timeline, parse_post_list
+from .base import parse_timeline, parse_blog_timeline

--- a/src/priviblur_extractor/parse/base.py
+++ b/src/priviblur_extractor/parse/base.py
@@ -4,10 +4,9 @@ def parse_timeline(initial_data):
     return collection_parsers.TimelineParser.process(initial_data["response"])
 
 
-def parse_blog_timeline(initial_data):
-    return collection_parsers.BlogTimelineParser.process(initial_data["response"])
-
-
-def parse_post_list(initial_data):
-    return collection_parsers.process_post_list(initial_data["response"])
+def parse_blog_timeline(initial_data, is_search = False):
+    if is_search:
+        return collection_parsers.BlogTimelineParser(initial_data["response"]).parse_blog_search_timeline()
+    else:
+        return collection_parsers.BlogTimelineParser.process(initial_data["response"])
 

--- a/src/priviblur_extractor/parse/collection_parsers.py
+++ b/src/priviblur_extractor/parse/collection_parsers.py
@@ -95,16 +95,20 @@ class BlogTimelineParser:
             next = cursor,
         )
 
+    def parse_blog_search_timeline(self):
+        cursor = _CursorParser.process(self.target)
 
-def process_post_list(target):
-    """Extracts a simple list of posts, with an attached cursor object"""
-    cursor = _CursorParser.process(target)
+        # Now the posts contained within
+        posts = []
+        total_raw_posts = len(self.target["posts"])
+        for post_index, post in enumerate(self.target["posts"]):
+            if result := items.parse_item(post, post_index, total_raw_posts):
+                posts.append(result)
 
-    # Now the posts contained within
-    posts = []
-    total_raw_posts = len(target["posts"])
-    for post_index, post in enumerate(target["posts"]):
-        if result := items.parse_item(post, post_index, total_raw_posts):
-            posts.append(result)
+        return models.timelines.BlogTimeline(
+            blog_info=posts[0].blog,
+            posts=posts,
+            total_posts = total_raw_posts,
+            next = cursor,
+        )
 
-    return posts, cursor

--- a/src/routes/blogs/blogs.py
+++ b/src/routes/blogs/blogs.py
@@ -59,21 +59,10 @@ async def _blog_search(request: sanic.Request, blog: str, query: str):
     blog = urllib.parse.unquote(blog)
     query = urllib.parse.unquote(query)
 
-    try:
-        if page := request.args.get("page"):
-            page = int(urllib.parse.unquote(page))
-    except ValueError:
-        page = None
+    if continuation := request.args.get("continuation"):
+        continuation = urllib.parse.unquote(continuation)
 
-    post_list = (await get_blog_search_results(request.app.ctx, blog, query, page=page))
-    blog_info = (await get_blog_posts(request.app.ctx, blog)).blog_info
-
-    blog = priviblur_extractor.models.timelines.BlogTimeline(
-        blog_info=blog_info,
-        posts = post_list,
-        total_posts=None,
-        next=None
-    )
+    blog = (await get_blog_search_results(request.app.ctx, blog, query, continuation=continuation))
 
     return await sanic_ext.render(
         "blog/blog_search.jinja",
@@ -81,7 +70,6 @@ async def _blog_search(request: sanic.Request, blog: str, query: str):
             "app": request.app,
             "blog": blog,
             "blog_search_query": query,
-            "page": page,
         }
     )
 

--- a/src/templates/blog/base_blog.jinja
+++ b/src/templates/blog/base_blog.jinja
@@ -25,4 +25,14 @@
     
     {%- block blog_contents %}
     {%- endblock %}
+
+    {%- if blog.next %}
+        <div class="paging">
+            {% block paging %}
+                <a class="primary next-page button" href="{{request.path}}?continuation={{blog.next.cursor | urlencode}}#m">
+                    {{translate(request.ctx.language, "pagination_next_page")}}
+                </a>
+            {% endblock%}
+        </div>
+    {% endif %}
 {%- endblock %}

--- a/src/templates/blog/blog.jinja
+++ b/src/templates/blog/blog.jinja
@@ -1,12 +1,4 @@
 {% extends "blog/base_blog.jinja" %}
 {% block blog_contents %}
     {% include 'components/blog_contents.jinja' %}
-
-    {%- if blog.next %}
-        <div class="paging">
-            <a class="primary next-page button" href="{{request.path}}?continuation={{blog.next.cursor | urlencode}}#m">
-                {{translate(request.ctx.language, "pagination_next_page")}}
-            </a>
-        </div>
-    {% endif %}
 {%- endblock %}

--- a/src/templates/blog/blog_search.jinja
+++ b/src/templates/blog/blog_search.jinja
@@ -2,16 +2,4 @@
 {% from 'macros/add_query.jinja' import add_query  %}
 {% block blog_contents %}
     {% include 'components/blog_contents.jinja' %}
-
-    {% if blog.posts %}
-        <div class="paging">
-            {%- block paging -%}
-                {% if page %}
-                    <a class="primary next-page button" href="{{-request.path}}?page={{page + 1}}">{{-translate(request.ctx.language, "pagination_next_page")}}</a>
-                {% else %}
-                    <a class="primary next-page button" href="{{-request.path}}?page=2">{{-translate(request.ctx.language, "pagination_next_page")}}</a>
-                {% endif %}
-            {%- endblock -%}
-        </div>
-    {% endif %}
 {%- endblock %}


### PR DESCRIPTION
Tumblr switched to continuation tokens for blog search and as such simple page numbers are no longer possible.

Closes #140 