### PR TITLE
Fix `.replace_from_cookie` logic and usage

### DIFF
--- a/src/preferences.py
+++ b/src/preferences.py
@@ -25,31 +25,31 @@ class UserPreferences:
         if self.theme not in ("auto", "light", "dark"):
             self.theme = "auto"
 
-    def replace_from_forms(self, request):
+    def replace_from_forms(self, request) -> 'UserPreferences':
         """Returns updated UserPreferences class from POST form data"""
         return self._replace(request, request.form)
 
-    def replace_from_query(self, request):
+    def replace_from_query(self, request) -> 'UserPreferences':
         """Returns updated UserPreferences class from request query args"""
         return self._replace(request, request.args)
 
-    def replace_from_cookie(self, request):
+    def replace_from_cookie(self, request) -> 'UserPreferences':
         """Returns updated UserPreferences class from the settings cookie"""
         request.ctx.invalid_settings_cookie = False
 
         try:
-
             if raw_prefs := request.cookies.get("settings"):
-                version = urllib.parse.parse_qs(raw_prefs)["version"][0]
+                raw_prefs = urllib.parse.parse_qs(raw_prefs)
+                version = raw_prefs["version"][0]
 
-                if version == VERSION:
-                    settings_from_cookie = urllib.parse.parse_qs(request.cookies.get("settings"))
-                    request.ctx.preferences = request.ctx.preferences._replace(settings_from_cookie)
+                if int(version) == VERSION:
+                    return request.ctx.preferences._replace(request, raw_prefs)
                 else:
                     request.ctx.invalid_settings_cookie = True
-
         except (TypeError, KeyError, ValueError):
             request.ctx.invalid_settings_cookie = True
+        
+        return self
 
     def _replace(self, request, raw_new_prefs):
         """Returns updated UserPreferences class from values in raw_new_prefs"""

--- a/src/server.py
+++ b/src/server.py
@@ -174,7 +174,7 @@ async def before_all_routes(request):
 
     request.ctx.language = request.ctx.preferences.language
 
-    request.ctx.preferences.replace_from_cookie(request)
+    request.ctx.preferences = request.ctx.preferences.replace_from_cookie(request)
 
 
 @app.middleware("response")


### PR DESCRIPTION
Commit ece53025d7f1f9212fc2d8c2cefe14cc7dd536dd introduced a bug where the setting cookie was not getting parsed due to faulty comparison logic (if int == string) and the lack of a proper return causing request.ctx.preferences to become None

Closes #151