### PR TITLE
Fix reblog attribution link directing to custom domains

### DIFF
--- a/src/helpers/helpers.py
+++ b/src/helpers/helpers.py
@@ -8,9 +8,14 @@ import sanic
 from ..cache import get_poll_results
 
 
-def url_handler(raw_url):
+def url_handler(url : str | urllib.parse.ParseResult):
     """Change URLs found in posts to privacy-friendly alternatives"""
-    url = urllib.parse.urlparse(raw_url)
+    if isinstance(url, str):
+        url = urllib.parse.urlparse(url)
+    elif isinstance(url, urllib.parse.ParseResult):
+        url = url
+    else:
+        raise ValueError
 
     hostname = url.hostname
 

--- a/src/priviblur_extractor/parse/items.py
+++ b/src/priviblur_extractor/parse/items.py
@@ -105,7 +105,6 @@ class PostParser:
         else:
             return None
 
-
     @staticmethod
     def parse_community_label(initial_data):
         community_labels = []
@@ -201,7 +200,9 @@ class PostParser:
         if reblogged_from_id := self.target.get("rebloggedFromId"):
             reblog_from_information = models.post.ReblogAttribution(
                 post_id=reblogged_from_id,
-                post_url=self.target["rebloggedFromUrl"],
+                # If a blog uses a custom domain then the rebloggedFromUrl will be that domain
+                # thus we'll try to extract the original tumblr URL from the parentPostUrl attr instead.
+                post_url=self.target["parentPostUrl"],
                 blog_name=self.target["rebloggedFromName"],
                 blog_title=self.target["rebloggedFromTitle"],
             )

--- a/src/server.py
+++ b/src/server.py
@@ -147,6 +147,7 @@ async def initialize(app):
     app.ext.environment.globals["url_handler"] = helpers.url_handler
     app.ext.environment.globals["format_npf"] = ext_npf_renderer.format_npf
     app.ext.environment.globals["create_poll_callback"] = helpers.create_poll_callback
+    app.ext.environment.globals["create_reblog_attribution"] = helpers.create_reblog_attribution_link
 
     app.ext.environment.tests["a_post"] = lambda element : isinstance(element, priviblur_extractor.models.post.Post)
 

--- a/src/templates/post/components/header.jinja
+++ b/src/templates/post/components/header.jinja
@@ -39,18 +39,8 @@
                 {#- The reblog from data can sometimes have an empty blog name. Thus we'll extract the name from the root reblog info if they're the same -#}
                 {# Though sometimes the reblog data is just hidden #}
                     <div class="reblog-attribution">
-                        {%- if not element.reblog_from.blog_name -%}
-                            {%- if element.reblog_root and element.reblog_root.post_id == element.reblog_from.post_id -%}
-                                {{reblog_icon(16, 16)}}
-                                <a class="link blog-name" href="{{url_handler(element.reblog_root.post_url)}}">{{element.reblog_root.blog_name}}</a>
-                            {%- else -%}
-                                {{reblog_icon(16, 16)}}
-                                <a class="link blog-name hidden-reblog" href="{{url_handler(element.reblog_from.post_url)}}">reblogged</a>
-                            {%- endif -%}
-                        {%- else -%}
-                            {{reblog_icon(16, 16)}}
-                            <a class="link blog-name" href="{{url_handler(element.reblog_from.post_url)}}">{{element.reblog_from.blog_name}}</a>
-                        {%- endif -%}
+                        {{reblog_icon(16, 16)}}
+                        {{create_reblog_attribution(element)}}
                     </div>
             {%- endif -%}
         </div>


### PR DESCRIPTION
On blogs with a custom domain the url given in rebloggedFrom*
and rebloggedRoot* will use their custom domain instead of a
regular tumblr domain.

In order to preserve the slug of the post priviblur uses the url given
from rebloggedFrom* and rebloggedRoot* which meant that users can be
directed to an external site unknowingly.

This PR fixes that by using the url given in the parentPostUrl
which should always be a regular tumblr link. Redundancy is also added
in that priviblur will check if the URL is a Tumblr domain and return
a span if it isn't and priviblur is unable to create a url to the original
post