### PR TITLE
Fix next page buttons appearing on empty blog searches

### DIFF
--- a/src/routes/blogs/blogs.py
+++ b/src/routes/blogs/blogs.py
@@ -63,17 +63,19 @@ async def _blog_search(request: sanic.Request, blog: str, query: str):
         continuation = urllib.parse.unquote(continuation)
 
     try:
-        blog = (await get_blog_search_results(request.app.ctx, blog, query, continuation=continuation))
+        blog_timeline = (await get_blog_search_results(request.app.ctx, blog, query, continuation=continuation))
     except IndexError:
-        # When no search results are found blog information will also be missing
-        blog = await get_blog_posts(request.app.ctx, blog)
-        blog.posts.clear()
+        blog_timeline = priviblur_extractor.models.timelines.BlogTimeline(
+            blog_info=(await get_blog_posts(request.app.ctx, blog)).blog_info,
+            posts=[],
+            total_posts=0
+        )
 
     return await sanic_ext.render(
         "blog/blog_search.jinja",
         context={
             "app": request.app,
-            "blog": blog,
+            "blog": blog_timeline,
             "blog_search_query": query,
         }
     )


### PR DESCRIPTION
Tumblr's internal API returns no data when no blog search results are found. This includes the necessary blog info to render the blog's header. 

#173 worked around this by instead requesting the main page of a blog and then clearing the posts list as to simulate empty results. However, it neglected to clear the next attribute which contains the data required to fetch the next batch of content and is used by the frontend to determine whether to render a next page button.

This oversight caused the frontend to display a next page button incorrectly which will cause an error if a user attempts to navigate to the next page.