### PR TITLE
Use `render_template` wrapper in all routes

### DIFF
--- a/src/exceptions/error_handlers/extractor_errors.py
+++ b/src/exceptions/error_handlers/extractor_errors.py
@@ -8,8 +8,8 @@ extractor_errors = _base.ErrorHandlerGroup()
 
 @extractor_errors.register(priviblur_exceptions.TumblrLoginRequiredError)
 async def tumblr_error_login_walled(request, exception):
-    return await sanic_ext.render(
-        "misc/msg_error.jinja",
+    return await request.app.ctx.render(
+        "misc/msg_error",
         context={
             "app": request.app,
             "exception": exception,
@@ -22,8 +22,8 @@ async def tumblr_error_login_walled(request, exception):
 
 @extractor_errors.register(priviblur_exceptions.TumblrRestrictedTagError)
 async def tumblr_error_restricted_tag(request, exception):
-    return await sanic_ext.render(
-        "misc/msg_error.jinja",
+    return await request.app.ctx.render(
+        "misc/msg_error",
         context={
             "app": request.app,
             "exception": exception,
@@ -36,8 +36,8 @@ async def tumblr_error_restricted_tag(request, exception):
 
 @extractor_errors.register(priviblur_exceptions.TumblrBlogNotFoundError)
 async def tumblr_error_unknown_blog(request, exception):
-    return await sanic_ext.render(
-        "misc/msg_error.jinja",
+    return await request.app.ctx.render(
+        "misc/msg_error",
         context={
             "app": request.app,
             "exception": exception,

--- a/src/exceptions/error_handlers/miscellaneous_errors.py
+++ b/src/exceptions/error_handlers/miscellaneous_errors.py
@@ -12,8 +12,8 @@ miscellaneous_errors = _base.ErrorHandlerGroup()
 
 @miscellaneous_errors.register(asyncio.TimeoutError)
 async def request_timeout(request, exception):
-    return await sanic_ext.render(
-        "misc/msg_error.jinja",
+    return await request.app.ctx.render(
+        "misc/msg_error",
         context={
             "app": request.app,
             "exception": exception,
@@ -26,8 +26,8 @@ async def request_timeout(request, exception):
 
 @miscellaneous_errors.register(sanic.exceptions.NotFound, IsADirectoryError)
 async def error_404(request, exception):
-    return await sanic_ext.render(
-        "misc/msg_error.jinja",
+    return await request.app.ctx.render(
+        "misc/msg_error",
         context={
             "app": request.app,
             "exception": exception,
@@ -40,8 +40,8 @@ async def error_404(request, exception):
 
 @miscellaneous_errors.register(exceptions.TumblrInvalidRedirect)
 async def invalid_redirect(request, exception):
-    return await sanic_ext.render(
-        "misc/msg_error.jinja",
+    return await request.app.ctx.render(
+        "misc/msg_error",
         context={
             "app": request.app,
             "exception": exception,
@@ -55,8 +55,8 @@ async def invalid_redirect(request, exception):
 async def generic_error(request, exception):
     name, message, context = _base.create_user_friendly_error_message(request, exception)
 
-    return await sanic_ext.render(
-        "misc/generic_error.jinja",
+    return await request.app.ctx.render(
+        "misc/generic_error",
         context={
             "app": request.app,
             "exception": exception,

--- a/src/helpers/render.py
+++ b/src/helpers/render.py
@@ -5,7 +5,7 @@ import sanic
 import sanic_ext
 
 # Wrapper around sanic_ext.render
-def render_template(
+async def render_template(
     template: str = "",
     context: Optional[Dict[str, Any]] = None,
     **kwargs
@@ -42,7 +42,7 @@ def render_template(
 
     template = f"{template}.jinja"
 
-    return sanic_ext.render(
+    return await sanic_ext.render(
         template,
         context=jinja_context,
         app=request.app,

--- a/src/routes/priviblur/misc.py
+++ b/src/routes/priviblur/misc.py
@@ -6,8 +6,8 @@ misc_bp = sanic.Blueprint("misc", url_prefix="/")
 
 @misc_bp.get("/licences")
 async def licences(request):
-    return await sanic_ext.render(
-        "misc/licenses.jinja",
+    return await request.app.ctx.render(
+        "misc/licenses",
         context={
             "app": request.app,
         }

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -8,8 +8,8 @@ settings = sanic.Blueprint("settings", url_prefix="/settings")
 
 @settings.get("/")
 async def settings_page(request):
-    return await sanic_ext.render(
-        "settings.jinja",
+    return await request.app.ctx.render(
+        "settings",
         context={
             "app": request.app,
         }
@@ -20,8 +20,8 @@ async def settings_page(request):
 async def settings_post(request):
     request.ctx.preferences = request.ctx.preferences.replace_from_forms(request)
 
-    response = await sanic_ext.render(
-        "settings.jinja",
+    response = await request.app.ctx.render(
+        "settings",
         context={
             "app": request.app,
         }
@@ -39,8 +39,8 @@ async def settings_post(request):
 async def settings_restore(request):
     request.ctx.preferences = request.ctx.preferences.replace_from_query(request)
 
-    response = await sanic_ext.render(
-        "settings.jinja",
+    response = await request.app.ctx.render(
+        "settings",
         context={
             "app": request.app,
         }


### PR DESCRIPTION
Also fixes the issue where the current routes using the `render_template` function weren't asynchronous