### PR TITLE
Re-add priviblur_extractor import in blog route

### DIFF
--- a/src/routes/blogs/blogs.py
+++ b/src/routes/blogs/blogs.py
@@ -2,6 +2,7 @@ import urllib.parse
 
 import sanic
 
+from ... import priviblur_extractor
 from ...cache import get_blog_posts, get_blog_search_results
 
 blogs = sanic.Blueprint("blogs", url_prefix="/")


### PR DESCRIPTION
The merger of #161 had accidentally caused this crucial import to get removed, causing an error on empty search results