### PR TITLE
add pb.cmc.pub

### DIFF
--- a/instances.md
+++ b/instances.md
@@ -7,7 +7,7 @@
 |[priviblur.pussthecat.org](https://priviblur.pussthecat.org)|Germany|No|No|
 |[priviblur.thebunny.zone](https://priviblur.thebunny.zone)|Croatia|No|No|
 |[priviblur.canine.tools](https://priviblur.canine.tools)|United States|No|No|
-|[priviblur.cmc.pub](https://priviblur.cmc.pub)|United States|No|No|
+|[pb.cmc.pub](https://pb.cmc.pub)|United States|No|No|
 
 
 ### Tor Onion Services

--- a/instances.md
+++ b/instances.md
@@ -7,6 +7,7 @@
 |[priviblur.pussthecat.org](https://priviblur.pussthecat.org)|Germany|No|No|
 |[priviblur.thebunny.zone](https://priviblur.thebunny.zone)|Croatia|No|No|
 |[priviblur.canine.tools](https://priviblur.canine.tools)|United States|No|No|
+|[priviblur.cmc.pub](https://priviblur.cmc.pub)|United States|No|No|
 
 
 ### Tor Onion Services


### PR DESCRIPTION
Adding `pb.cmc.pub` as an instance.

Please let me know if I need to flip the Cloudflare to yes. DNS runs through Cloudflare but proxying is NOT enabled, so it doesn't use Cloudflare's proxy network.