### PR TITLE
update cmc.pub to cleberg.net

### DIFF
--- a/instances.md
+++ b/instances.md
@@ -7,7 +7,7 @@
 |[priviblur.pussthecat.org](https://priviblur.pussthecat.org)|Germany|No|No|
 |[priviblur.thebunny.zone](https://priviblur.thebunny.zone)|Croatia|No|No|
 |[priviblur.canine.tools](https://priviblur.canine.tools)|United States|No|No|
-|[pb.cmc.pub](https://pb.cmc.pub)|United States|No|No|
+|[pb.cleberg.net](https://pb.cleberg.net)|United States|No|No|
 
 
 ### Tor Onion Services


### PR DESCRIPTION
Apologies for the quick change from https://github.com/syeopite/priviblur/pull/214, but cmc.pub was getting caught in spam filters/zscaler/etc., so I reverted to cleberg.net, which is my long-standing domain.

Thanks!