### PR TITLE
fix regex digits warnings

### DIFF
--- a/src/routes/api/v1/misc.py
+++ b/src/routes/api/v1/misc.py
@@ -7,7 +7,7 @@ from ....cache import get_poll_results
 misc = sanic.Blueprint("api_misc", url_prefix="/")
 
 
-@misc.get("/poll/<blog:([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})>/<post_id:int>/<poll_id:str>/results")
+@misc.get(r"/poll/<blog:([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})>/<post_id:int>/<poll_id:str>/results")
 async def poll_results(request, blog: str, post_id: int, poll_id: int):
     blog = urllib.parse.unquote(blog)
     poll_id = urllib.parse.unquote(poll_id)

--- a/src/routes/api/v1/misc.py
+++ b/src/routes/api/v1/misc.py
@@ -7,7 +7,9 @@ from ....cache import get_poll_results
 misc = sanic.Blueprint("api_misc", url_prefix="/")
 
 
-@misc.get(r"/poll/<blog:([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})>/<post_id:int>/<poll_id:str>/results")
+@misc.get(
+    r"/poll/<blog:([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})>/<post_id:int>/<poll_id:str>/results"
+)
 async def poll_results(request, blog: str, post_id: int, poll_id: int):
     blog = urllib.parse.unquote(blog)
     poll_id = urllib.parse.unquote(poll_id)

--- a/src/routes/blogs/__init__.py
+++ b/src/routes/blogs/__init__.py
@@ -3,5 +3,5 @@ from sanic import Blueprint
 from . import blogs, post
 
 blogs_group = Blueprint.group(
-    blogs.blogs, post.blog_post_bp, url_prefix="/<blog:([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})>"
+    blogs.blogs, post.blog_post_bp, url_prefix=r"/<blog:([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})>"
 )


### PR DESCRIPTION
Fixes Warning Caused by `\d` as python needs `\\d` for regex.