### PR TITLE
Add docker ecosystem to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
 
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This should make update PRs to Dockerfile FROM instructions to the latest version when available